### PR TITLE
Change to only trap the Eject key when a Shift key is down

### DIFF
--- a/peripherals/macOS/WAR Control.xcodeproj/project.pbxproj
+++ b/peripherals/macOS/WAR Control.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		2F2524A9210F9F260044686A /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		2F2524AB210F9F260044686A /* WAR_Control.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WAR_Control.entitlements; sourceTree = "<group>"; };
 		2F25A179221C6C2100EB245C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		2F9C0A0822FDEE3200FEBA02 /* MediaKey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaKey.h; sourceTree = "<group>"; };
 		2FA664CA2156754300C755A7 /* BLEPeripheral.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BLEPeripheral.h; sourceTree = "<group>"; };
 		2FA664CB2156754300C755A7 /* BLEPeripheral.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BLEPeripheral.m; sourceTree = "<group>"; };
 		2FA664CD2156BC1700C755A7 /* MediaKeyTapDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaKeyTapDelegate.h; sourceTree = "<group>"; };
@@ -92,6 +93,7 @@
 				2FA664CB2156754300C755A7 /* BLEPeripheral.m */,
 				2FA664CD2156BC1700C755A7 /* MediaKeyTapDelegate.h */,
 				2F25A17A221C6C2100EB245C /* InfoPlist.strings */,
+				2F9C0A0822FDEE3200FEBA02 /* MediaKey.h */,
 			);
 			path = "WAR Control";
 			sourceTree = "<group>";

--- a/peripherals/macOS/WAR Control/AppDelegate.m
+++ b/peripherals/macOS/WAR Control/AppDelegate.m
@@ -10,7 +10,7 @@
 #import "MediaKeyTap.h"
 #import "BLEPeripheral.h"
 
-@interface AppDelegate () <BLEPeripheralDelegate, NSUserNotificationCenterDelegate>
+@interface AppDelegate () <BLEPeripheralDelegate, MediaKeyTapDelegate, NSUserNotificationCenterDelegate>
 {
 	NSStatusItem* statusItem;
 	MediaKeyTap* tap;
@@ -23,6 +23,8 @@
 @end
 
 @implementation AppDelegate
+@dynamic active;
+
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification
 {
 	// Add the status item
@@ -38,7 +40,7 @@
 	
 	// Instantiate the BLE peripheral, and media key hook
 	peripheral = [[BLEPeripheral alloc] initWithDelegate:self];
-	tap = [[MediaKeyTap alloc] initWithDelegate:peripheral];
+	tap = [[MediaKeyTap alloc] initWithDelegate:self];
 
 	// Install the hook/handler
 	[peripheral start];
@@ -64,6 +66,7 @@
 	}
 }
 
+#pragma mark BLEPeripheral Delegate
 - (void)didSubscribe:(nonnull NSString *)central
 {
 	NSLog( @"didSubscribe: %@", central );
@@ -84,6 +87,7 @@
 	[defaultUserNotificationCenter deliverNotification:notification];
 }
 
+#pragma mark User Notification Center Delegate
 - (void)userNotificationCenter:(NSUserNotificationCenter *)center didDeliverNotification:(NSUserNotification *)notification
 {
 	NSLog( @"Delivered notification: %@ %@", notification.title, notification.informativeText );
@@ -92,6 +96,28 @@
 - (BOOL)userNotificationCenter:(NSUserNotificationCenter *)center shouldPresentNotification:(NSUserNotification *)notification
 {
 	NSLog( @"shouldPresentNotification: %@ %@", notification.title, notification.informativeText );
+	return YES;
+}
+
+#pragma mark Media Key Tap Delegate
+- (BOOL)active
+{
+	return (peripheral.subscribers > 0);
+}
+
+- (BOOL)keyDown:(MediaKey)key
+{
+	return [peripheral notify:key isDown:YES];
+}
+
+- (BOOL)keyUp:(MediaKey)key
+{
+	return [peripheral notify:key isDown:NO];
+}
+
+- (BOOL)eject
+{
+	[NSApp terminate:nil];
 	return YES;
 }
 @end

--- a/peripherals/macOS/WAR Control/BLEPeripheral.h
+++ b/peripherals/macOS/WAR Control/BLEPeripheral.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import "MediaKeyTapDelegate.h"
+#import "MediaKey.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -17,10 +17,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)didUnsubscribe:(NSString*)central;
 @end
 
-@interface BLEPeripheral : NSObject <MediaKeyTapDelegate>
+@interface BLEPeripheral : NSObject
+@property (readonly) NSUInteger subscribers;
+
 - (instancetype)initWithDelegate:(NSObject<BLEPeripheralDelegate>*)aDelegate;
 - (void)start;
 - (void)stop;
+- (BOOL)notify:(MediaKey)key isDown:(BOOL)down;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/peripherals/macOS/WAR Control/Info.plist
+++ b/peripherals/macOS/WAR Control/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.1</string>
+	<string>1.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>2</string>
+	<string>1</string>
 	<key>LSHasLocalizedDisplayName</key>
 	<true/>
 	<key>LSMinimumSystemVersion</key>

--- a/peripherals/macOS/WAR Control/MediaKey.h
+++ b/peripherals/macOS/WAR Control/MediaKey.h
@@ -1,0 +1,25 @@
+//
+//  MediaKey.h
+//  WAR Control
+//
+//  Created by Stephen Higgins on 09/08/2019.
+//  Copyright © 2019 Stephen Higgins. All rights reserved.
+//
+
+#ifndef MediaKey_h
+#define MediaKey_h
+
+typedef enum {
+	
+	MediaKeyInvalid = 0x00,
+	MediaKeyPlayPause = 0x01,
+	MediaKeyBack = 0x02,
+	MediaKeyForward = 0x04,
+	MediaKeyVolumeUp = 0x08,
+	MediaKeyVolumeDown = 0x10,
+	MediaKeyVolumeMute = 0x20,
+	MediaKeyToggleVibrate = (MediaKeyVolumeMute|MediaKeyVolumeDown|MediaKeyVolumeUp)
+	
+} MediaKey;
+
+#endif /* MediaKey_h */

--- a/peripherals/macOS/WAR Control/MediaKeyTap.m
+++ b/peripherals/macOS/WAR Control/MediaKeyTap.m
@@ -156,12 +156,12 @@ CGEventRef tapEventCallback(CGEventTapProxy, CGEventType, CGEventRef, void *);
 			break;
 
 		case NX_KEYTYPE_EJECT:
-			if ((keyState != NX_KEYSTATE_DOWN)
-				|| (event.modifierFlags & NSEventModifierFlagDeviceIndependentFlagsMask)){
-				// Do nothing
-				;
-			}else{
-				[delegate eject];
+			if (keyState == NX_KEYSTATE_DOWN){
+				const NSEventModifierFlags flags = (event.modifierFlags & NSEventModifierFlagDeviceIndependentFlagsMask);
+				if (flags == NSEventModifierFlagShift){
+					NSLog( @"Eject! Eject! Eject!" );
+					[delegate eject];
+				}
 			}
 
 			// Fall through

--- a/peripherals/macOS/WAR Control/MediaKeyTapDelegate.h
+++ b/peripherals/macOS/WAR Control/MediaKeyTapDelegate.h
@@ -6,21 +6,10 @@
 //  Copyright © 2018-19 Stephen Higgins. All rights reserved.
 //
 
+#include "MediaKey.h"
+
 #ifndef MediaKeyTapDelegate_h
 #define MediaKeyTapDelegate_h
-
-typedef enum {
-	
-	MediaKeyInvalid = 0x00,
-	MediaKeyPlayPause = 0x01,
-	MediaKeyBack = 0x02,
-	MediaKeyForward = 0x04,
-	MediaKeyVolumeUp = 0x08,
-	MediaKeyVolumeDown = 0x10,
-	MediaKeyVolumeMute = 0x20,
-	MediaKeyToggleVibrate = (MediaKeyVolumeMute|MediaKeyVolumeDown|MediaKeyVolumeUp)
-
-} MediaKey;
 
 @protocol MediaKeyTapDelegate
 @property (readonly) BOOL active;


### PR DESCRIPTION
Also: de-couple the `tap` and `peripheral` and intermediate them with the application instance